### PR TITLE
fix to device object instances

### DIFF
--- a/core/device.go
+++ b/core/device.go
@@ -91,14 +91,16 @@ func (d *Device) ParseCoreLinks(links []*encoding.CoreLink) {
 		if err != nil {
 			continue
 		}
-		objId := uint16(id)
-		obj := node.NewObject(objId)
+		obj, ok := objs[objId]
+		if !ok {
+			obj = node.NewObject(objId)
+			objs[objId] = obj
+		}
 		if len(sps) == 2 {
 			if insId, err := strconv.Atoi(sps[1]); err == nil {
 				obj.Instances[uint16(insId)] = node.NewObjectInstance(uint16(insId))
 			}
 		}
-		objs[objId] = obj
 	}
 	d.objLock.Lock()
 	d.objs = objs


### PR DESCRIPTION
Fixes the behaviour where only the last object instance was stored, overriding all previous instances that were parsed. Now, it correctly adds new instances.