### PR TITLE
init text and opaque content-format

### DIFF
--- a/core/device.go
+++ b/core/device.go
@@ -39,23 +39,6 @@ func NewBinding(b string) Binding {
 	}
 }
 
-var (
-	_tlvAcceptOption     message.Option
-	_tlvAcceptOptionOnce sync.Once
-)
-
-func _acceptOption() message.Option {
-	_tlvAcceptOptionOnce.Do(func() {
-		buf := make([]byte, 2)
-		l, _ := message.EncodeUint32(buf, uint32(message.AppLwm2mTLV))
-		_tlvAcceptOption = message.Option{
-			ID:    message.Accept,
-			Value: buf[:l],
-		}
-	})
-	return _tlvAcceptOption
-}
-
 type observationEvent struct {
 	p node.Path
 	n []node.Node
@@ -78,6 +61,31 @@ type Device struct {
 
 	observations sync.Map //map[node.Path]Observation
 	obsChan      chan observationEvent
+
+	acceptMediaType message.MediaType
+	writeMediaType  message.MediaType
+	acceptOption    message.Option
+}
+
+var DefaultMediaType = message.AppLwm2mTLV
+
+func (d *Device) SetMediaTypes(acceptMediaType, writeMediaType message.MediaType) {
+	d.acceptMediaType = acceptMediaType
+	d.writeMediaType = writeMediaType
+
+	// generate option once
+	buf := make([]byte, 2)
+	_, _ = message.EncodeUint32(buf, uint32(acceptMediaType))
+	d.acceptOption = message.Option{
+		ID:    message.Accept,
+		Value: buf[:],
+	}
+}
+func (d *Device) GetAcceptMediaType() message.MediaType {
+	return d.acceptMediaType
+}
+func (d *Device) GetWriteMediaType() message.MediaType {
+	return d.writeMediaType
 }
 
 func (d *Device) ParseCoreLinks(links []*encoding.CoreLink) {
@@ -176,7 +184,7 @@ func (d *Device) processObservation(k node.Path) (mux.Observation, error) {
 			p: k,
 			n: nodes,
 		}
-	}, _acceptOption())
+	}, d.acceptOption)
 }
 
 func (d *Device) String() string {
@@ -275,7 +283,7 @@ func (d *Device) HasObjectInstance(id, iid uint16) bool {
 }
 
 func (d *Device) Read(ctx context.Context, p node.Path) ([]node.Node, error) {
-	msg, err := d.conn.Get(ctx, p.String(), _acceptOption())
+	msg, err := d.conn.Get(ctx, p.String(), d.acceptOption)
 	if err != nil {
 		return nil, err
 	}
@@ -302,11 +310,11 @@ func (d *Device) ReadResource(ctx context.Context, p node.Path) (*node.Resource,
 }
 
 func (d *Device) Write(ctx context.Context, p node.Path, val ...node.Node) error {
-	msg, err := node.EncodeMessage(message.AppLwm2mTLV, val)
+	msg, err := node.EncodeMessage(d.writeMediaType, val)
 	if err != nil {
 		return err
 	}
-	resp, err := d.conn.Put(ctx, p.String(), message.AppLwm2mTLV, msg, _acceptOption())
+	resp, err := d.conn.Put(ctx, p.String(), d.writeMediaType, msg, d.acceptOption)
 	if err != nil {
 		return err
 	}
@@ -361,11 +369,11 @@ func (d *Device) Create(ctx context.Context, p node.Path, val *node.Object) erro
 	if !p.IsObject() {
 		return node.ErrPathInvalidValue
 	}
-	msg, err := node.EncodeMessage(message.AppLwm2mTLV, []node.Node{val})
+	msg, err := node.EncodeMessage(d.writeMediaType, []node.Node{val})
 	if err != nil {
 		return err
 	}
-	resp, err := d.conn.Post(ctx, p.String(), message.AppLwm2mTLV, msg)
+	resp, err := d.conn.Post(ctx, p.String(), d.writeMediaType, msg)
 	if err != nil {
 		return err
 	}

--- a/core/device.go
+++ b/core/device.go
@@ -389,7 +389,7 @@ func (d *Device) Delete(ctx context.Context, p node.Path) error {
 	if !p.IsObjectInstance() {
 		return node.ErrPathInvalidValue
 	}
-	resp, err := d.conn.Delete(ctx, p.String(), _acceptOption())
+	resp, err := d.conn.Delete(ctx, p.String(), d.acceptOption)
 	if err != nil {
 		return err
 	}

--- a/core/manager.go
+++ b/core/manager.go
@@ -288,6 +288,7 @@ func (d *manager) Register(req *RegisterRequest, links []*encoding.CoreLink, con
 		Manager:     d,
 		obsChan:     make(chan observationEvent, 10),
 	}
+	dev.SetMediaTypes(DefaultMediaType, DefaultMediaType)
 	if links != nil && len(links) > 0 {
 		dev.ParseCoreLinks(links)
 	}

--- a/encoding/opaque.go
+++ b/encoding/opaque.go
@@ -1,0 +1,97 @@
+package encoding
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+)
+
+// Opaque value should be used for binary resources like firmware image
+// although  define it for every type
+// with same rules as Value field in TLV
+
+type OpaqueValue struct {
+	Value []byte
+}
+
+func (o *OpaqueValue) StringVal() string {
+	return string(o.Value)
+}
+
+func (o *OpaqueValue) Integer() (val int64, err error) {
+	buff := bytes.NewBuffer(o.Value)
+	if len(o.Value) == 1 {
+		var i1 int8
+		err = binary.Read(buff, binary.BigEndian, &i1)
+		val = int64(i1)
+	} else if len(o.Value) == 2 {
+		var i2 int16
+		err = binary.Read(buff, binary.BigEndian, &i2)
+		val = int64(i2)
+	} else if len(o.Value) == 4 {
+		var i4 int32
+		err = binary.Read(buff, binary.BigEndian, &i4)
+		val = int64(i4)
+	} else if len(o.Value) == 8 {
+		var i8 int64
+		err = binary.Read(buff, binary.BigEndian, &i8)
+		val = i8
+	} else {
+		err = ErrTlvInvalidLength
+	}
+	return
+}
+
+func (o *OpaqueValue) Float() (float64, error) {
+	if len(o.Value) == 4 {
+		return float64(math.Float32frombits(binary.BigEndian.Uint32(o.Value))), nil
+	} else if len(o.Value) == 8 {
+		return math.Float64frombits(binary.BigEndian.Uint64(o.Value)), nil
+	} else {
+		return 0, ErrTlvInvalidLength
+	}
+}
+
+func (o *OpaqueValue) Boolean() (val bool, err error) {
+	if len(o.Value) != 1 {
+		return false, ErrTlvInvalidLength
+	}
+	val = o.Value[0] != 0
+	return val, nil
+}
+
+func (o *OpaqueValue) Opaque() []byte {
+	return o.Value
+}
+
+func (o *OpaqueValue) Time() (int64, error) {
+	if len(o.Value) == 4 {
+		return int64(binary.BigEndian.Uint32(o.Value)), nil
+	} else if len(o.Value) == 8 {
+		return int64(binary.BigEndian.Uint64(o.Value)), nil
+	} else {
+		return 0, ErrTlvInvalidLength
+	}
+}
+
+func (o *OpaqueValue) ObjectLink() (uint16, uint16, error) {
+	if len(o.Value) != 4 {
+		return 0, 0, ErrTlvInvalidLength
+	}
+	_ = o.Value[3]
+	return uint16(o.Value[0])*256 + uint16(o.Value[1]),
+		uint16(o.Value[2])*256 + uint16(o.Value[3]), nil
+}
+
+func (o *OpaqueValue) Raw() []byte {
+	return o.Value
+}
+
+func NewOpaqueValue(val any) (*OpaqueValue, error) {
+	buf := new(bytes.Buffer)
+	err := binary.Write(buf, binary.BigEndian, val)
+	if err != nil {
+		return nil, err
+	}
+	return &OpaqueValue{Value: buf.Bytes()}, nil
+}

--- a/encoding/opaque_test.go
+++ b/encoding/opaque_test.go
@@ -1,0 +1,57 @@
+package encoding
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestOpaque(t *testing.T) {
+	{ // int -> int64
+		val, err := NewOpaqueValue(42)
+		assert.Nil(t, err)
+		assert.Equal(t, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2a}, val.Raw())
+	}
+	{ // int64
+		val, err := NewOpaqueValue(int64(42))
+		assert.Nil(t, err)
+		assert.Equal(t, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2a}, val.Raw())
+	}
+	{ // int32
+		val, err := NewOpaqueValue(int32(42))
+		assert.Nil(t, err)
+		assert.Equal(t, []byte{0x00, 0x00, 0x00, 0x2a}, val.Raw())
+	}
+	{ // int16
+		val, err := NewOpaqueValue(int16(42))
+		assert.Nil(t, err)
+		assert.Equal(t, []byte{0x00, 0x2a}, val.Raw())
+	}
+	{ // float #1
+		val, err := NewOpaqueValue(42.0)
+		assert.Nil(t, err)
+		assert.Equal(t, []byte{0x40, 0x45, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, val.Raw())
+	}
+	{ // float #2
+		val, err := NewOpaqueValue(3.14151617181920)
+		assert.Nil(t, err)
+		assert.Equal(t, []byte{0x40, 0x09, 0x21, 0xd3, 0x3b, 0xe, 0x8c, 0x74}, val.Raw())
+	}
+	{ // string
+		val, err := NewOpaqueValue("3.14151617181920")
+		assert.Nil(t, err)
+		assert.Equal(t, []byte("3.14151617181920"), val.Raw())
+	}
+	{ // bool
+		val, err := NewOpaqueValue(true)
+		assert.Nil(t, err)
+		assert.Equal(t, []byte{0x01}, val.Raw())
+		val, err = NewOpaqueValue(false)
+		assert.Equal(t, nil, err)
+		assert.Equal(t, []byte{0x00}, val.Raw())
+	}
+	{ // opaque
+		val, err := NewOpaqueValue([]byte{0x01, 0x02, 0x03, 0x04})
+		assert.Nil(t, err)
+		assert.Equal(t, []byte{0x01, 0x02, 0x03, 0x04}, val.Raw())
+	}
+}

--- a/encoding/textplain.go
+++ b/encoding/textplain.go
@@ -1,0 +1,144 @@
+package encoding
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type PlainTextValue struct {
+	Value []byte
+}
+
+func (p *PlainTextValue) StringVal() string {
+	return string(p.Value)
+}
+
+func (p *PlainTextValue) Integer() (val int64, err error) {
+	return strconv.ParseInt(string(p.Value), 10, 64)
+}
+
+func (p *PlainTextValue) Float() (float64, error) {
+	return strconv.ParseFloat(string(p.Value), 64)
+}
+
+func (p *PlainTextValue) Boolean() (val bool, err error) {
+	// Represented as the ASCII value 0 or 1
+	if string(p.Value) == "1" {
+		return true, nil
+	} else if string(p.Value) == "0" {
+		return false, nil
+	}
+	return false, errors.New("not a boolean representation")
+}
+
+func (p *PlainTextValue) Opaque() []byte {
+	// Represented as a Base64 encoding of binary bytes
+	opaque, err := base64.StdEncoding.DecodeString(string(p.Value))
+	if err != nil {
+		return nil
+	}
+	return opaque
+}
+
+func (p *PlainTextValue) Time() (int64, error) {
+	// same as integer
+	return p.Integer()
+}
+
+func (p *PlainTextValue) ObjectLink() (uint16, uint16, error) {
+	splitted := strings.Split(string(p.Value), ":")
+	if len(splitted) != 2 {
+		return 0, 0, errors.New("wrong ObjLink text representation")
+	}
+	od, err := strconv.ParseUint(splitted[0], 10, 16)
+	if err != nil {
+		return 0, 0, err
+	}
+	oid, err := strconv.ParseUint(splitted[1], 10, 16)
+	if err != nil {
+		return 0, 0, err
+	}
+	return uint16(od), uint16(oid), nil
+}
+
+func (p *PlainTextValue) Raw() []byte {
+	return p.Value
+}
+
+func NewPlainTextRaw(data []byte) *PlainTextValue {
+	return &PlainTextValue{Value: data}
+}
+
+func (p *PlainTextValue) fromInteger(val int64) error {
+	str := fmt.Sprintf("%d", val)
+	p.Value = []byte(str)
+	return nil
+}
+func (p *PlainTextValue) fromFloat(val float64) error {
+	str := fmt.Sprintf("%v", val)
+	p.Value = []byte(str)
+	return nil
+}
+func (p *PlainTextValue) fromBool(val bool) error {
+	str := "0"
+	if val {
+		str = "1"
+	}
+	p.Value = []byte(str)
+	return nil
+}
+func (p *PlainTextValue) fromTime(val int64) error {
+	return p.fromInteger(val)
+}
+func (p *PlainTextValue) fromString(val string) error {
+	p.Value = []byte(val)
+	return nil
+}
+func (p *PlainTextValue) fromOpaque(val []byte) error {
+	raw := base64.StdEncoding.EncodeToString(val)
+	p.Value = []byte(raw)
+	return nil
+}
+func NewPlainTextValue(val any) (*PlainTextValue, error) {
+	var pt PlainTextValue
+	var err error
+	switch val.(type) {
+	case int:
+		err = pt.fromInteger(int64(val.(int)))
+	case int8:
+		err = pt.fromInteger(int64(val.(int8)))
+	case int16:
+		err = pt.fromInteger(int64(val.(int16)))
+	case int32:
+		err = pt.fromInteger(int64(val.(int32)))
+	case int64:
+		err = pt.fromInteger(val.(int64))
+	case uint:
+		err = pt.fromInteger(int64(val.(uint)))
+	case uint8:
+		err = pt.fromInteger(int64(val.(uint8)))
+	case uint16:
+		err = pt.fromInteger(int64(val.(uint16)))
+	case uint32:
+		err = pt.fromInteger(int64(val.(uint32)))
+	case float32:
+		err = pt.fromFloat(float64(val.(float32)))
+	case float64:
+		err = pt.fromFloat(val.(float64))
+	case string:
+		err = pt.fromString(val.(string))
+	case []byte:
+		err = pt.fromOpaque(val.([]byte))
+	case bool:
+		err = pt.fromBool(val.(bool))
+	default:
+		err = errors.New("unknown type")
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &pt, err
+}

--- a/encoding/textplain_test.go
+++ b/encoding/textplain_test.go
@@ -1,0 +1,42 @@
+package encoding
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestPlainText(t *testing.T) {
+	{ // int
+		val, err := NewPlainTextValue(42)
+		assert.Nil(t, err)
+		assert.Equal(t, []byte("42"), val.Raw())
+	}
+	{ // float #1
+		val, err := NewPlainTextValue(42.21)
+		assert.Nil(t, err)
+		assert.Equal(t, []byte("42.21"), val.Raw())
+	}
+	{ // float #2
+		val, err := NewPlainTextValue(3.14151617181920)
+		assert.Nil(t, err)
+		assert.Equal(t, []byte("3.1415161718192"), val.Raw())
+	}
+	{ // string
+		val, err := NewPlainTextValue("3.14151617181920")
+		assert.Nil(t, err)
+		assert.Equal(t, []byte("3.14151617181920"), val.Raw())
+	}
+	{ // bool
+		val, err := NewPlainTextValue(true)
+		assert.Nil(t, err)
+		assert.Equal(t, []byte("1"), val.Raw())
+		val, err = NewPlainTextValue(false)
+		assert.Equal(t, nil, err)
+		assert.Equal(t, []byte("0"), val.Raw())
+	}
+	{ // opaque
+		val, err := NewPlainTextValue([]byte{0x01, 0x02, 0x03, 0x04})
+		assert.Nil(t, err)
+		assert.Equal(t, []byte("AQIDBA=="), val.Raw())
+	}
+}

--- a/examples/content-format/main.go
+++ b/examples/content-format/main.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/plgd-dev/go-coap/v3/message"
+	"github.com/yplam/lwm2m/core"
+	"github.com/yplam/lwm2m/encoding"
+	"github.com/yplam/lwm2m/node"
+	"github.com/yplam/lwm2m/registration"
+	"github.com/yplam/lwm2m/server"
+	"log"
+	"time"
+)
+
+func onDeviceStateChange(e core.DeviceEvent, m core.Manager) {
+	device := e.Device
+	switch e.EventType {
+	case core.DevicePostRegister:
+		device.SetMediaTypes(message.TextPlain, message.TextPlain)
+		if device.HasObjectWithInstance(1) {
+			go func() {
+				ctx := context.Background()
+				op, _ := node.NewPathFromString("/1")
+				oip, _ := node.NewPathFromString("/1/0")
+				rp, _ := node.NewPathFromString("/1/0/1")
+				if n, err := device.Discover(ctx, op); err == nil {
+					fmt.Printf("links %v\n", n)
+				}
+
+				if v, err := device.Read(ctx, rp); err == nil {
+					fmt.Printf("Read: %v\n", v)
+				}
+				time.Sleep(time.Second * 1)
+				if v, err := device.ReadResource(ctx, rp); err == nil {
+					fmt.Printf("Resource: %v\n", v)
+				}
+				time.Sleep(time.Second * 1)
+				if v, err := device.ReadObject(ctx, op); err == nil {
+					fmt.Printf("Object: %v\n", v)
+				}
+				time.Sleep(time.Second * 1)
+				value := encoding.NewTlv(encoding.TlvSingleResource, 1, uint16(123))
+				if value != nil {
+					if res, err := node.NewSingleResource(rp, value); err == nil {
+						if err = device.WriteResource(ctx, rp, res); err == nil {
+							fmt.Printf("Write resource ok\n")
+						} else {
+							fmt.Println("error writing resource: ", err)
+						}
+					} else {
+						fmt.Println("error creating resource", err)
+					}
+				}
+				time.Sleep(time.Second * 1)
+				if v, err := device.ReadResource(ctx, rp); err == nil {
+					fmt.Printf("Resource: %v\n", v)
+				}
+				time.Sleep(time.Second * 1)
+				value = encoding.NewTlv(encoding.TlvSingleResource, 5850, true)
+				if value != nil {
+					if res, err := node.NewSingleResource(rp, value); err == nil {
+						obi := node.NewObjectInstance(0)
+						obi.Resources[5850] = res
+						if err = device.WriteObjectInstance(ctx, oip, obi); err == nil {
+							fmt.Printf("Write object instance ok\n")
+						}
+					}
+
+				}
+				time.Sleep(time.Second * 1)
+				if v, err := device.ReadResource(ctx, rp); err == nil {
+					fmt.Printf("Resource: %v\n", v)
+				}
+			}()
+
+		}
+	default:
+
+	}
+}
+
+func main() {
+	r := server.DefaultRouter()
+	manager := core.DefaultManager()
+	manager.OnDeviceStateChange(onDeviceStateChange)
+	registration.EnableHandler(r, manager)
+
+	err := server.ListenAndServe(r,
+		server.EnableUDPListener("udp", ":5683"))
+	if err != nil {
+		log.Printf("Serve lwm2m with err: %v\n", err)
+	}
+}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -176,3 +176,137 @@ func TestDecodeMultipleInstanceObjectTLV(t *testing.T) {
 	assert.Equal(t, true, ok)
 	assert.Equal(t, true, res.isMultiple)
 }
+
+func decodePlainText(t *testing.T, str string) ([]Node, error) {
+	msg := pool.NewMessage(context.Background())
+	msg.SetContentFormat(message.TextPlain)
+	msg.SetBody(bytes.NewReader([]byte(str)))
+	return DecodeMessage(NewResourcePath(1, 0, 1), msg)
+}
+func TestDecodePlainText(t *testing.T) {
+
+	{ // payload #0
+		data := "0"
+		nn, err := decodePlainText(t, data)
+		assert.Nil(t, err)
+		assert.Len(t, nn, 1)
+		n := nn[0]
+		switch n.(type) {
+		case *Resource:
+			rr, _ := n.(*Resource)
+			bb, err := rr.Data().Boolean()
+			assert.Nil(t, err)
+			assert.False(t, bb)
+			ii, err := rr.Data().Integer()
+			assert.Nil(t, err)
+			assert.Equal(t, int64(0), ii)
+			ff, err := rr.Data().Float()
+			assert.Nil(t, err)
+			assert.Equal(t, float64(0.0), ff)
+			ss := rr.Data().StringVal()
+			assert.Equal(t, data, ss)
+			op := rr.Data().Opaque()
+			assert.Nil(t, op)
+		default:
+			t.Fatal("not Resource")
+		}
+	}
+
+	{ // payload #1
+		data := "11.10"
+		nn, err := decodePlainText(t, data)
+		assert.Nil(t, err)
+		assert.Len(t, nn, 1)
+		n := nn[0]
+		switch n.(type) {
+		case *Resource:
+			rr, _ := n.(*Resource)
+			_, err = rr.Data().Boolean()
+			assert.NotNil(t, err)
+			_, err = rr.Data().Integer()
+			assert.NotNil(t, err)
+			ff, err := rr.Data().Float()
+			assert.Nil(t, err)
+			assert.Equal(t, float64(11.1), ff)
+			ss := rr.Data().StringVal()
+			assert.Equal(t, "11.10", ss)
+			op := rr.Data().Opaque()
+			assert.Nil(t, op)
+		default:
+			t.Fatal("not Resource")
+		}
+	}
+	{ // payload #2
+		data := "AQIDBA=="
+		nn, err := decodePlainText(t, data)
+		assert.Nil(t, err)
+		assert.Len(t, nn, 1)
+		n := nn[0]
+		switch n.(type) {
+		case *Resource:
+			rr, _ := n.(*Resource)
+			_, err = rr.Data().Boolean()
+			assert.NotNil(t, err)
+			_, err = rr.Data().Integer()
+			assert.NotNil(t, err)
+			_, err = rr.Data().Float()
+			assert.NotNil(t, err)
+			ss := rr.Data().StringVal()
+			assert.Equal(t, data, ss)
+			op := rr.Data().Opaque()
+			assert.True(t, bytes.Equal(op, []byte{0x01, 0x02, 0x03, 0x04}))
+		default:
+			t.Fatal("not Resource")
+		}
+	}
+	{ // payload #3
+		data := "1"
+		nn, err := decodePlainText(t, data)
+		assert.Nil(t, err)
+		assert.Len(t, nn, 1)
+		n := nn[0]
+		switch n.(type) {
+		case *Resource:
+			rr, _ := n.(*Resource)
+			bb, err := rr.Data().Boolean()
+			assert.Nil(t, err)
+			assert.True(t, bb)
+			ii, err := rr.Data().Integer()
+			assert.Nil(t, err)
+			assert.Equal(t, int64(1), ii)
+			ff, err := rr.Data().Float()
+			assert.Nil(t, err)
+			assert.Equal(t, 1.0, ff)
+			ss := rr.Data().StringVal()
+			assert.Equal(t, data, ss)
+			op := rr.Data().Opaque()
+			assert.Nil(t, op)
+		default:
+			t.Fatal("not Resource")
+		}
+	}
+	{ // payload #4
+		data := "hello friend"
+		nn, err := decodePlainText(t, data)
+		assert.Nil(t, err)
+		assert.Len(t, nn, 1)
+		n := nn[0]
+		switch n.(type) {
+		case *Resource:
+			rr, _ := n.(*Resource)
+			_, err = rr.Data().Boolean()
+			assert.NotNil(t, err)
+			_, err = rr.Data().Integer()
+			assert.NotNil(t, err)
+			_, err = rr.Data().Float()
+			assert.NotNil(t, err)
+			ss := rr.Data().StringVal()
+			assert.Equal(t, data, ss)
+			op := rr.Data().Opaque()
+			assert.Nil(t, op)
+			rr.Data().Raw()
+		default:
+			t.Fatal("not Resource")
+		}
+	}
+}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -304,7 +304,117 @@ func TestDecodePlainText(t *testing.T) {
 			assert.Equal(t, data, ss)
 			op := rr.Data().Opaque()
 			assert.Nil(t, op)
-			rr.Data().Raw()
+		default:
+			t.Fatal("not Resource")
+		}
+	}
+}
+
+func decodeAppOctets(t *testing.T, data []byte) ([]Node, error) {
+	msg := pool.NewMessage(context.Background())
+	msg.SetContentFormat(message.AppOctets)
+	msg.SetBody(bytes.NewReader(data))
+	return DecodeMessage(NewResourcePath(1, 0, 1), msg)
+}
+func TestDecodeOpaque(t *testing.T) {
+
+	{ // payload #0
+		data := []byte{0x00}
+		nn, err := decodeAppOctets(t, data)
+		assert.Nil(t, err)
+		assert.Len(t, nn, 1)
+		n := nn[0]
+		switch n.(type) {
+		case *Resource:
+			rr, _ := n.(*Resource)
+			bb, err := rr.Data().Boolean()
+			assert.Nil(t, err)
+			assert.False(t, bb)
+			ii, err := rr.Data().Integer()
+			assert.Nil(t, err)
+			assert.Equal(t, int64(0), ii)
+			_, err = rr.Data().Float()
+			assert.NotNil(t, err)
+			ss := rr.Data().StringVal()
+			assert.Equal(t, string([]byte{0x00}), ss)
+			op := rr.Data().Opaque()
+			assert.NotNil(t, op)
+			assert.Equal(t, []byte{0x00}, op)
+		default:
+			t.Fatal("not Resource")
+		}
+	}
+
+	{ // payload #1
+		data := []byte{0x40, 0x09, 0x21, 0xd3, 0x3b, 0xe, 0x8c, 0x74}
+		nn, err := decodeAppOctets(t, data)
+		assert.Nil(t, err)
+		assert.Len(t, nn, 1)
+		n := nn[0]
+		switch n.(type) {
+		case *Resource:
+			rr, _ := n.(*Resource)
+			_, err := rr.Data().Boolean()
+			assert.NotNil(t, err)
+			ii, err := rr.Data().Integer()
+			assert.Nil(t, err)
+			assert.Equal(t, int64(4614256484330409076), ii)
+			ff, err := rr.Data().Float()
+			assert.Nil(t, err)
+			assert.Equal(t, float64(3.14151617181920), ff)
+			ss := rr.Data().StringVal()
+			assert.Equal(t, string([]byte{0x40, 0x09, 0x21, 0xd3, 0x3b, 0xe, 0x8c, 0x74}), ss)
+			op := rr.Data().Opaque()
+			assert.NotNil(t, op)
+			assert.Equal(t, []byte{0x40, 0x09, 0x21, 0xd3, 0x3b, 0xe, 0x8c, 0x74}, op)
+		default:
+			t.Fatal("not Resource")
+		}
+	}
+	{ // payload #2
+		data := "long long string dorem ipsum; once upon a time in a far away lands..."
+		nn, err := decodeAppOctets(t, []byte(data))
+		assert.Nil(t, err)
+		assert.Len(t, nn, 1)
+		n := nn[0]
+		switch n.(type) {
+		case *Resource:
+			rr, _ := n.(*Resource)
+			_, err = rr.Data().Boolean()
+			assert.NotNil(t, err)
+			_, err = rr.Data().Integer()
+			assert.NotNil(t, err)
+			_, err = rr.Data().Float()
+			assert.NotNil(t, err)
+			ss := rr.Data().StringVal()
+			assert.Equal(t, data, ss)
+			op := rr.Data().Opaque()
+			assert.True(t, bytes.Equal(op, []byte(data)))
+		default:
+			t.Fatal("not Resource")
+		}
+	}
+	{ // payload #3
+		data := "1"
+		nn, err := decodeAppOctets(t, []byte(data))
+		assert.Nil(t, err)
+		assert.Len(t, nn, 1)
+		n := nn[0]
+		switch n.(type) {
+		case *Resource:
+			rr, _ := n.(*Resource)
+			_, err = rr.Data().Boolean()
+			assert.NotNil(t, err)
+			ii, err := rr.Data().Integer()
+			assert.Nil(t, err)
+			assert.Equal(t, int64(49), ii)
+			_, err = rr.Data().Float()
+			assert.NotNil(t, err)
+			ss := rr.Data().StringVal()
+			assert.Equal(t, data, ss)
+			op := rr.Data().Opaque()
+			assert.NotNil(t, op)
+			assert.Equal(t, []byte{0x31}, op)
 		default:
 			t.Fatal("not Resource")
 		}


### PR DESCRIPTION
Hi.

Implemented encoding/decoding for TextPlain and AppOctets content types.
There is new methods:
* `Device.SetMediaTypes(acceptMediaType, writeMediaType)`
* `Device.GetAcceptMediaType()`
* `Device.GetWriteMediaType()`

So it is possible to change content-type for device at any time.
