### PR TITLE
fix handleDelete: nil device dereference

### DIFF
--- a/registration/handler.go
+++ b/registration/handler.go
@@ -132,13 +132,11 @@ func (h *Handler) handleUpdate(w mux.ResponseWriter, r *mux.Message, id string) 
 }
 
 func (h *Handler) handleDelete(w mux.ResponseWriter, r *mux.Message, id string) {
-	d, err := h.manager.GetDevice(id)
-	if err != nil || d == nil {
+	if err := h.manager.Deregister(id); err == nil {
+		_ = w.SetResponse(codes.Deleted, message.TextPlain, nil)
+	} else {
 		_ = w.SetResponse(codes.NotFound, message.TextPlain, nil)
-		return
 	}
-	_ = w.SetResponse(codes.Deleted, message.TextPlain, nil)
-	_ = h.manager.Deregister(d.Id)
 }
 
 func EnableHandler(r *mux.Router, m core.Manager, opts ...Option) {


### PR DESCRIPTION
`go run ./examples/simple/main.go`
I used https://github.com/eclipse/wakaama/tree/master/examples/lightclient to connect.

I got error in following case: after successful registration if lightclient I restart server.
When I terminate it with `Ctrl-C` it sends DELETE request to deregister from server.
Device is not registered, therefore it  `d == nil`. Server tries to get `d.Id` in any case.

```text
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x65b0d8]

goroutine 18 [running]:
github.com/yplam/lwm2m/registration.(*Handler).handleDelete(0xc00007d6e0, {0x9b4be8, 0xc00009c030}, 0xc0000a00c0?, {0xc00009e099?, 0xc00007d590?})
```
