### PR TITLE
Bootstrap server

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1,0 +1,1 @@
+package bootstrap

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1,1 +1,119 @@
 package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"github.com/plgd-dev/go-coap/v3/message"
+	"github.com/plgd-dev/go-coap/v3/message/codes"
+	"github.com/plgd-dev/go-coap/v3/mux"
+	"github.com/yplam/lwm2m/core"
+	"github.com/yplam/lwm2m/encoding"
+	"github.com/yplam/lwm2m/node"
+	"io"
+)
+
+type Client struct {
+	Endpoint   string
+	conn       mux.Conn
+	selectedCt message.MediaType
+}
+
+func (c *Client) ContentType() message.MediaType {
+	return c.selectedCt
+}
+
+func (c *Client) SetContentType(ct message.MediaType) {
+	c.selectedCt = ct
+}
+
+func (c *Client) finish(ctx context.Context) (err error) {
+	res, err := c.conn.Post(ctx, "/bs", c.selectedCt, nil)
+	if err != nil {
+		return err
+	}
+	if res.Code() != codes.Changed {
+		return fmt.Errorf("unexpected response code: %v", res.Code())
+	}
+	return nil
+}
+
+func (c *Client) Conn() mux.Conn {
+	return c.conn
+}
+
+func (c *Client) Write(ctx context.Context, path node.Path, val ...node.Node) error {
+	msg, err := node.EncodeMessage(c.selectedCt, val)
+	if err != nil {
+		return err
+	}
+	resp, err := c.conn.Put(ctx, path.String(), c.selectedCt, msg)
+	if err != nil {
+		return err
+	}
+	if resp.Code() != codes.Changed {
+		return fmt.Errorf("unexpected response code: %v", resp.Code())
+	}
+	return nil
+}
+
+func (c *Client) Read(ctx context.Context, path node.Path) ([]node.Node, error) {
+
+	// accept
+	buf := make([]byte, 2)
+	_, _ = message.EncodeUint32(buf, uint32(c.selectedCt))
+	acceptOption := message.Option{
+		ID:    message.Accept,
+		Value: buf[:],
+	}
+
+	msg, err := c.conn.Get(ctx, path.String(), acceptOption)
+	if err != nil {
+		return nil, err
+	}
+	if msg.Code() != codes.Content {
+		return nil, fmt.Errorf("unexpected response code: %v", msg.Code())
+	}
+	if msg.Body() == nil {
+		return nil, core.ErrEmptyBody
+	}
+	return node.DecodeMessage(path, msg)
+}
+
+func (c *Client) Discover(ctx context.Context, path node.Path) ([]*encoding.CoreLink, error) {
+
+	buf := make([]byte, 2)
+	l, _ := message.EncodeUint32(buf, uint32(message.AppLinkFormat))
+	r, err := c.conn.Get(ctx, path.String(),
+		message.Option{
+			ID:    message.Accept,
+			Value: buf[:l],
+		})
+	if err != nil {
+		return nil, err
+	}
+	if r.Code() != codes.Content {
+		return nil, fmt.Errorf("unexpected response code: %v", r.Code())
+	}
+	links := make([]*encoding.CoreLink, 0)
+	if r.Body() != nil {
+		if b, err := io.ReadAll(r.Body()); err == nil {
+			links, _ = encoding.CoreLinksFromString(string(b))
+		}
+	}
+	return links, nil
+}
+
+func (c *Client) Delete(ctx context.Context, path node.Path) (err error) {
+	resp, err := c.conn.Delete(ctx, path.String())
+	if err != nil {
+		return err
+	}
+	if resp.Code() != codes.Deleted {
+		return fmt.Errorf("unexpected response code: %v", resp.Code())
+	}
+	return nil
+}
+
+type Provider interface {
+	HandleBsRequest(ctx context.Context, device *Client) error
+}

--- a/bootstrap/handler.go
+++ b/bootstrap/handler.go
@@ -1,0 +1,1 @@
+package bootstrap

--- a/bootstrap/handler.go
+++ b/bootstrap/handler.go
@@ -16,6 +16,8 @@ import (
 
 const DefaultBootstrapTimeout = 30 * time.Second
 
+var DefaultContentType = message.AppLwm2mTLV
+
 type Handler struct {
 	timeout  time.Duration
 	logger   logging.LeveledLogger
@@ -60,10 +62,12 @@ func (h *Handler) ServeCOAP(w mux.ResponseWriter, r *mux.Message) {
 	// select content type
 	switch pct {
 	case message.AppLwm2mTLV:
+	case message.TextPlain:
+	case message.AppOctets:
 	default:
-		err = fmt.Errorf("unsupported content type: %s", pct.String())
-		w.SetResponse(codes.BadRequest, message.TextPlain, bytes.NewReader([]byte(err.Error())))
-		return
+		h.logger.Debugf("client prefer unsupported(yet) content-type %s", pct.String())
+		h.logger.Debugf("using %s as default", DefaultContentType.String())
+		pct = DefaultContentType
 	}
 
 	client := &Client{

--- a/bootstrap/handler.go
+++ b/bootstrap/handler.go
@@ -1,1 +1,115 @@
 package bootstrap
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/pion/logging"
+	"github.com/plgd-dev/go-coap/v3/message"
+	"github.com/plgd-dev/go-coap/v3/message/codes"
+	"github.com/plgd-dev/go-coap/v3/mux"
+	"github.com/yplam/lwm2m/core"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const DefaultBootstrapTimeout = 30 * time.Second
+
+type Handler struct {
+	timeout  time.Duration
+	logger   logging.LeveledLogger
+	provider Provider
+}
+
+func (h *Handler) ServeCOAP(w mux.ResponseWriter, r *mux.Message) {
+	h.logger.Debugf("bootstrap serve coap: %v", r)
+
+	ep := ""                                                    // endpoint, optional
+	pctOpt := strconv.FormatInt(int64(message.AppLwm2mTLV), 10) // preferred content-type, optional
+	opts := r.Options()
+	for _, o := range opts {
+		h.logger.Debugf("option: %s, %d", string(o.Value), o.ID)
+		if o.ID != message.URIQuery {
+			continue
+		}
+		so := strings.Split(string(o.Value), "=")
+		if len(so) != 2 {
+			w.SetResponse(codes.BadRequest, message.TextPlain, bytes.NewReader([]byte("bad uri query")))
+			return
+		}
+		switch so[0] {
+		case "ep":
+			ep = so[1]
+		case "pct":
+			pctOpt = so[1]
+		default:
+			w.SetResponse(codes.BadRequest, message.TextPlain, bytes.NewReader([]byte("unsupported option")))
+			return
+		}
+	}
+
+	ipct, err := strconv.ParseUint(pctOpt, 10, 16)
+	if err != nil {
+		err = fmt.Errorf("parse pct option: %w", err)
+		w.SetResponse(codes.BadRequest, message.TextPlain, bytes.NewReader([]byte(err.Error())))
+		return
+	}
+	pct := message.MediaType(ipct)
+
+	// select content type
+	switch pct {
+	case message.AppLwm2mTLV:
+	default:
+		err = fmt.Errorf("unsupported content type: %s", pct.String())
+		w.SetResponse(codes.BadRequest, message.TextPlain, bytes.NewReader([]byte(err.Error())))
+		return
+	}
+
+	client := &Client{
+		Endpoint:   ep,
+		conn:       w.Conn(),
+		selectedCt: pct,
+	}
+
+	core.SetLifetime(client.conn, h.timeout)
+
+	err = w.SetResponse(codes.Changed, client.selectedCt, nil)
+	if err != nil {
+		h.logger.Errorf("error sending response to bootstrap request: %v", err)
+		return
+	}
+
+	// limit bootstrap procedure by timeout with ctx
+	ctx, cancel := context.WithTimeout(context.TODO(), h.timeout)
+	go func() {
+		defer func() {
+			// send finish message in any case
+			err := client.finish(context.TODO())
+			if err != nil {
+				h.logger.Errorf("error sending bootstrap-finish: %v", err)
+			}
+			cancel()
+		}()
+		err := h.provider.HandleBsRequest(ctx, client)
+		if err != nil {
+			h.logger.Errorf("bootstrap provider err: %v", err)
+			return
+		}
+	}()
+}
+
+func EnableHandler(r *mux.Router, p Provider, opts ...Option) {
+	h := &Handler{
+		provider: p,
+		timeout:  DefaultBootstrapTimeout,
+	}
+	for _, opt := range opts {
+		opt(h)
+	}
+	if h.logger == nil {
+		lf := logging.NewDefaultLoggerFactory()
+		h.logger = lf.NewLogger("bootstrap")
+	}
+	_ = r.Handle("/bs", h)
+}

--- a/bootstrap/option.go
+++ b/bootstrap/option.go
@@ -1,0 +1,20 @@
+package bootstrap
+
+import (
+	"context"
+	"github.com/pion/logging"
+)
+
+type Option func(h *Handler)
+
+func WithLogger(l logging.LeveledLogger) Option {
+	return func(h *Handler) {
+		h.logger = l
+	}
+}
+
+func WithParentContext(c context.Context) Option {
+	return func(h *Handler) {
+		h.ctx = c
+	}
+}

--- a/bootstrap/option.go
+++ b/bootstrap/option.go
@@ -1,8 +1,8 @@
 package bootstrap
 
 import (
-	"context"
 	"github.com/pion/logging"
+	"time"
 )
 
 type Option func(h *Handler)
@@ -13,8 +13,8 @@ func WithLogger(l logging.LeveledLogger) Option {
 	}
 }
 
-func WithParentContext(c context.Context) Option {
+func WithBootstrapTimeout(timeout time.Duration) Option {
 	return func(h *Handler) {
-		h.ctx = c
+		h.timeout = timeout
 	}
 }

--- a/core/inactivitymonitor.go
+++ b/core/inactivitymonitor.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	dtlsServer "github.com/plgd-dev/go-coap/v3/dtls/server"
+	"github.com/plgd-dev/go-coap/v3/mux"
 	"github.com/plgd-dev/go-coap/v3/net/monitor/inactivity"
 	"github.com/plgd-dev/go-coap/v3/options"
 	tcpClient "github.com/plgd-dev/go-coap/v3/tcp/client"
@@ -102,6 +103,10 @@ const lifetimeCtxKey lifetimeCtxKeyType = "core_lifetime"
 
 func WithLifetime(ctx context.Context, lifetime time.Duration) context.Context {
 	return context.WithValue(ctx, lifetimeCtxKey, lifetime)
+}
+
+func SetLifetime(c mux.Conn, d time.Duration) {
+	c.SetContextValue(lifetimeCtxKey, d)
 }
 
 func GetLifetime(ctx context.Context) *time.Duration {

--- a/examples/bootstrap/main.go
+++ b/examples/bootstrap/main.go
@@ -1,0 +1,2 @@
+package main
+

--- a/examples/bootstrap/main.go
+++ b/examples/bootstrap/main.go
@@ -1,2 +1,359 @@
 package main
 
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"github.com/plgd-dev/go-coap/v3/message"
+	"github.com/yplam/lwm2m/bootstrap"
+	"github.com/yplam/lwm2m/encoding"
+	"github.com/yplam/lwm2m/node"
+	"github.com/yplam/lwm2m/server"
+	"log"
+)
+
+var ct = ""
+
+type BootstrapProvider struct {
+}
+
+func check(err error) {
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func (p *BootstrapProvider) HandleBsRequest(ctx context.Context, client *bootstrap.Client) error {
+	fmt.Println("handle bs request for client: ", client.Endpoint)
+
+	switch ct {
+	case "":
+		// should use preferred by device
+	case "text":
+		client.SetContentType(message.TextPlain)
+	case "opaque":
+		client.SetContentType(message.AppOctets)
+	case "tlv":
+		client.SetContentType(message.AppLwm2mTLV)
+	default:
+		return errors.New("unknown content type")
+	}
+
+	pp, _ := node.NewPathFromString("/0")
+	err := client.Delete(ctx, pp)
+	check(err)
+	pp, _ = node.NewPathFromString("/1")
+	err = client.Delete(ctx, pp)
+	check(err)
+
+	if client.ContentType() == message.TextPlain {
+		// this scope for plaintext. although it is not in specs it should work
+		// let's make a try
+		// $ ./wakaama-client -b
+
+		{
+			// uri resource
+			p := "/0/1/0"
+			pp, _ := node.NewPathFromString(p)
+			vv, _ := encoding.NewPlainTextValue("coap://localhost:5683")
+			val, err := node.NewSingleResource(pp, vv)
+			check(err)
+			err = client.Write(ctx, pp, val)
+			check(err)
+		}
+		{
+			// is bootstrap server?
+			p := "/0/1/1"
+			pp, _ := node.NewPathFromString(p)
+			vv, _ := encoding.NewPlainTextValue(false)
+			val, _ := node.NewSingleResource(pp, vv)
+			err = client.Write(ctx, pp, val)
+			check(err)
+		}
+		{
+			// security mode
+			p := "/0/1/2"
+			pp, _ := node.NewPathFromString(p)
+			vv, _ := encoding.NewPlainTextValue(3)
+			val, _ := node.NewSingleResource(pp, vv)
+			err = client.Write(ctx, pp, val)
+			check(err)
+		}
+		{
+			// short server id
+			p := "/0/1/10"
+			pp, _ := node.NewPathFromString(p)
+			vv, _ := encoding.NewPlainTextValue(1)
+			val, _ := node.NewSingleResource(pp, vv)
+			err = client.Write(ctx, pp, val)
+			check(err)
+		}
+
+		{
+			// short server id
+			p := "/1/0/0"
+			pp, _ := node.NewPathFromString(p)
+			vv, _ := encoding.NewPlainTextValue(1)
+			val, _ := node.NewSingleResource(pp, vv)
+			err = client.Write(ctx, pp, val)
+			check(err)
+		}
+		{
+			// lifetime
+			p := "/1/0/1"
+			pp, _ := node.NewPathFromString(p)
+			vv, _ := encoding.NewPlainTextValue(42)
+			val, _ := node.NewSingleResource(pp, vv)
+			err = client.Write(ctx, pp, val)
+			check(err)
+		}
+		{
+			// notification storing when disabled or offline
+			p := "/1/0/6"
+			pp, _ := node.NewPathFromString(p)
+			vv, _ := encoding.NewPlainTextValue(false)
+			val, _ := node.NewSingleResource(pp, vv)
+			err = client.Write(ctx, pp, val)
+			check(err)
+		}
+		{
+			// binding
+			p := "/1/0/7"
+			pp, _ := node.NewPathFromString(p)
+			vv, _ := encoding.NewPlainTextValue("U")
+			val, _ := node.NewSingleResource(pp, vv)
+			err = client.Write(ctx, pp, val)
+			check(err)
+		}
+	} else if client.ContentType() == message.AppOctets {
+
+		{
+			// uri resource
+			p := "/0/1/0"
+			pp, _ := node.NewPathFromString(p)
+			vv, _ := encoding.NewOpaqueValue("coap://localhost:5683")
+			val, err := node.NewSingleResource(pp, vv)
+			check(err)
+			err = client.Write(ctx, pp, val)
+			check(err)
+		}
+		{
+			// is bootstrap server?
+			p := "/0/1/1"
+			pp, _ := node.NewPathFromString(p)
+			vv, _ := encoding.NewOpaqueValue(false)
+			val, _ := node.NewSingleResource(pp, vv)
+			err = client.Write(ctx, pp, val)
+			check(err)
+		}
+		{
+			// security mode
+			p := "/0/1/2"
+			pp, _ := node.NewPathFromString(p)
+			vv, _ := encoding.NewOpaqueValue(3)
+			val, _ := node.NewSingleResource(pp, vv)
+			err = client.Write(ctx, pp, val)
+			check(err)
+		}
+		{
+			// short server id
+			p := "/0/1/10"
+			pp, _ := node.NewPathFromString(p)
+			vv, _ := encoding.NewOpaqueValue(1)
+			val, _ := node.NewSingleResource(pp, vv)
+			err = client.Write(ctx, pp, val)
+			check(err)
+		}
+
+		{
+			// short server id
+			p := "/1/0/0"
+			pp, _ := node.NewPathFromString(p)
+			vv, _ := encoding.NewOpaqueValue(1)
+			val, _ := node.NewSingleResource(pp, vv)
+			err = client.Write(ctx, pp, val)
+			check(err)
+		}
+		{
+			// lifetime
+			p := "/1/0/1"
+			pp, _ := node.NewPathFromString(p)
+			vv, _ := encoding.NewOpaqueValue(42)
+			val, _ := node.NewSingleResource(pp, vv)
+			err = client.Write(ctx, pp, val)
+			check(err)
+		}
+		{
+			// notification storing when disabled or offline
+			p := "/1/0/6"
+			pp, _ := node.NewPathFromString(p)
+			vv, _ := encoding.NewOpaqueValue(false)
+			val, _ := node.NewSingleResource(pp, vv)
+			err = client.Write(ctx, pp, val)
+			check(err)
+		}
+		{
+			// binding
+			p := "/1/0/7"
+			pp, _ := node.NewPathFromString(p)
+			vv, _ := encoding.NewOpaqueValue("U")
+			val, _ := node.NewSingleResource(pp, vv)
+			err = client.Write(ctx, pp, val)
+			check(err)
+		}
+
+	} else if client.ContentType() == message.AppLwm2mTLV {
+
+		oi0 := node.NewObjectInstance(1)
+		{
+			// uri resource
+			p := "/0/1/0"
+			id := uint16(0)
+			pp, _ := node.NewPathFromString(p)
+			val := encoding.NewTlv(encoding.TlvSingleResource, id, "coap://localhost:5683")
+			res, _ := node.NewSingleResource(pp, val)
+			oi0.SetResource(id, res)
+		}
+		{
+			// is bootstrap server?
+			p := "/0/1/1"
+			id := uint16(1)
+			pp, _ := node.NewPathFromString(p)
+			val := encoding.NewTlv(encoding.TlvSingleResource, id, false)
+			res, _ := node.NewSingleResource(pp, val)
+			oi0.SetResource(id, res)
+		}
+		{
+			// security mode
+			p := "/0/1/2"
+			id := uint16(2)
+			pp, _ := node.NewPathFromString(p)
+			val := encoding.NewTlv(encoding.TlvSingleResource, id, uint16(3))
+			res, _ := node.NewSingleResource(pp, val)
+			oi0.SetResource(id, res)
+		}
+		{
+			// short server id
+			p := "/0/1/10"
+			id := uint16(10)
+			pp, _ := node.NewPathFromString(p)
+			val := encoding.NewTlv(encoding.TlvSingleResource, id, uint16(1))
+			res, _ := node.NewSingleResource(pp, val)
+			oi0.SetResource(id, res)
+		}
+
+		oi1 := node.NewObjectInstance(0)
+		{
+			// short server id
+			p := "/1/0/0"
+			id := uint16(0)
+			pp, _ := node.NewPathFromString(p)
+			val := encoding.NewTlv(encoding.TlvSingleResource, id, uint16(1))
+			res, _ := node.NewSingleResource(pp, val)
+			oi1.SetResource(id, res)
+		}
+		{
+			// lifetime
+			p := "/1/0/1"
+			id := uint16(1)
+			pp, _ := node.NewPathFromString(p)
+			val := encoding.NewTlv(encoding.TlvSingleResource, id, int64(42))
+			res, _ := node.NewSingleResource(pp, val)
+			oi1.SetResource(id, res)
+		}
+		{
+			// notification storing when disabled or offline
+			p := "/1/0/6"
+			id := uint16(6)
+			pp, _ := node.NewPathFromString(p)
+			val := encoding.NewTlv(encoding.TlvSingleResource, id, false)
+			res, _ := node.NewSingleResource(pp, val)
+			oi1.SetResource(id, res)
+		}
+		{
+			// binding
+			p := "/1/0/7"
+			id := uint16(7)
+			pp, _ := node.NewPathFromString(p)
+			val := encoding.NewTlv(encoding.TlvSingleResource, id, "U")
+			res, _ := node.NewSingleResource(pp, val)
+			oi1.SetResource(id, res)
+		}
+
+		pp, _ = node.NewPathFromString("/0/1")
+		err = client.Write(ctx, pp, oi0)
+		check(err)
+		pp, _ = node.NewPathFromString("/1/0")
+		err = client.Write(ctx, pp, oi1)
+		check(err)
+	}
+
+	{
+		// read and discover
+		pp, _ = node.NewPathFromString("/1/0/1")
+		res, err := client.Read(ctx, pp)
+		fmt.Println(res, err)
+
+		pp, _ = node.NewPathFromString("/1/0")
+		res, err = client.Read(ctx, pp)
+		fmt.Println(res, err)
+
+		pp, _ = node.NewPathFromString("/1")
+		res, err = client.Read(ctx, pp)
+		fmt.Println(res, err)
+
+		pp, _ = node.NewPathFromString("/0")
+		res, err = client.Read(ctx, pp)
+		fmt.Println(res, err)
+
+		pp, _ = node.NewPathFromString("/0/1")
+		res, err = client.Read(ctx, pp)
+		fmt.Println(res, err)
+
+		pp, _ = node.NewPathFromString("/0/1/0")
+		res, err = client.Read(ctx, pp)
+		fmt.Println(res, err)
+
+		pp, err = node.NewPathFromString("")
+		check(err)
+		links, err := client.Discover(ctx, pp)
+		fmt.Println(links, err)
+
+		pp, err = node.NewPathFromString("/")
+		check(err)
+		links, err = client.Discover(ctx, pp)
+		fmt.Println(links, err)
+
+		pp, _ = node.NewPathFromString("/1")
+		links, err = client.Discover(ctx, pp)
+		fmt.Println(links, err)
+
+		pp, _ = node.NewPathFromString("/1/0")
+		links, err = client.Discover(ctx, pp)
+		fmt.Println(links, err)
+
+		pp, _ = node.NewPathFromString("/0/1")
+		links, err = client.Discover(ctx, pp)
+		fmt.Println(links, err)
+	}
+
+	fmt.Println("bootstrap finished without errors")
+	return nil
+}
+
+func main() {
+	flag.StringVar(&ct, "format", "", "text/tlv/opaque. if not set then default(tlv) or preferred by client will be used.")
+	flag.Parse()
+	fmt.Println("bootstrap server demo")
+
+	r := server.DefaultRouter()
+	provider := &BootstrapProvider{}
+	bootstrap.EnableHandler(r, provider)
+	err := server.ListenAndServe(r,
+		server.EnableUDPListener("udp", ":5685"),
+	)
+	if err != nil {
+		log.Printf("serve bootstrap with err: %v", err)
+	}
+}

--- a/node/registry.go
+++ b/node/registry.go
@@ -189,7 +189,7 @@ func loadObjectDefinition(x []byte) (*ObjectDefinition, error) {
 		return nil, err
 	}
 	xo := xx.Object
-	if xo.ObjectID <= 0 {
+	if xo.ObjectID < 0 {
 		return nil, errors.New("no object definition found")
 	}
 	var res = make(map[uint16]*ResourceDefinition)

--- a/node/registry_test.go
+++ b/node/registry_test.go
@@ -17,7 +17,7 @@ func TestNewRegistry(t *testing.T) {
 }
 
 func validateRegistryTest(t *testing.T, reg *Registry) {
-	assert.Equal(t, len(reg.objs), 287)
+	assert.Equal(t, len(reg.objs), 288)
 	assert.Equal(t, reg.objs[3].Name, "Device")
 }
 


### PR DESCRIPTION
There is bootstrap sequence implemented.
Sending initial response to `/bs` request and finishing (POST `/bs` from server) is done by ServeCOAP method.
The rest(DELETE, WRITE, DISCOVER, READ) should be implemented in user-defined `Provider`.

I'm not sure how to test it properly, did only with `wakaama-client -b`. Should be there `*_test.go` written?

Don't insist on immediate accepting, cause I guess there is a room to work.
Take a look and give feedback.
